### PR TITLE
CI: Add nginx version 1.23.x and 1.24.x

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -135,6 +135,8 @@ jobs:
           - 1.20.x
           - 1.21.x
           - 1.22.x
+          - 1.23.x
+          - 1.24.x
         ARCH:
           - x86_64
           - aarch64
@@ -189,6 +191,8 @@ jobs:
           - 1.20.x
           - 1.21.x
           - 1.22.x
+          - 1.23.x
+          - 1.24.x
     steps:
       - name: Install dependencies
         run: brew install gsed jq openssl@1.1 pcre zlib
@@ -233,6 +237,8 @@ jobs:
           - 1.20.x
           - 1.21.x
           - 1.22.x
+          - 1.23.x
+          - 1.24.x
     steps:
       - name: Remove nginx/njs from NGINX_MODULES (not supported on Windows)
         shell: bash

--- a/README.adoc
+++ b/README.adoc
@@ -234,7 +234,10 @@ Suffix `.exe` is used for Windows binaries only.
 1.19.x (EOL) footnote:[The first available nginx version in branch 1.19.x is 1.19.5.] +
 1.20.x (old stable) +
 1.21.x (old mainline) +
-1.22.x (stable)
+1.22.x (old stable) +
+1.23.x (mainline) +
+1.24.x (stable)
+
 .3+| _default_
 | Linux
 | x86_64 +


### PR DESCRIPTION
this PR would address https://github.com/jirutka/nginx-binaries/issues/6 

From nginx.org site:

> 2023-04-11 | nginx-1.24.0 stable version has been released, incorporating new features and bug fixes from the 1.23.x mainline branch  — including improved handling of multiple header lines with identical names, memory usage optimization in configurations with SSL proxying, better sanity checking of the listen directive protocol parameters, TLSv1.3 protocol enabled by default, automatic rotation of TLS session tickets encryption keys when using shared memory in the ssl_session_cache directive, and more.

